### PR TITLE
Add minimal Flask backend and React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# testmyapp
+# CMS Ecommerce App
+
+This project is a simple CMS ecommerce demo using a Python Flask backend and a React frontend.
+
+## Backend
+
+See [backend/README.md](backend/README.md) for setup instructions.
+
+## Frontend
+
+Open [frontend/index.html](frontend/index.html) in your browser after starting the backend.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,12 @@
+# Backend - Flask API
+
+This is a minimal Flask API serving product data for the CMS ecommerce app.
+
+## Setup
+
+```
+python3 -m venv venv
+source venv/bin/activate
+pip install Flask
+python backend/app.py
+```

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,26 @@
+from flask import Flask, jsonify, request
+
+app = Flask(__name__)
+
+# Sample in-memory data store
+products = [
+    {"id": 1, "name": "Sample Product", "price": 10.0}
+]
+
+@app.route('/products', methods=['GET'])
+def list_products():
+    return jsonify(products)
+
+@app.route('/products', methods=['POST'])
+def create_product():
+    data = request.get_json(force=True)
+    product = {
+        "id": len(products) + 1,
+        "name": data.get("name"),
+        "price": data.get("price", 0.0)
+    }
+    products.append(product)
+    return jsonify(product), 201
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,4 @@
+# Frontend - React
+
+This is a minimal React frontend served as a static HTML file.
+Open `index.html` in your browser after starting the backend.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CMS Ecommerce App</title>
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel">
+      const App = () => {
+        const [products, setProducts] = React.useState([]);
+        const [name, setName] = React.useState('');
+        const [price, setPrice] = React.useState('');
+
+        React.useEffect(() => {
+          fetch('/products')
+            .then(res => res.json())
+            .then(data => setProducts(data));
+        }, []);
+
+        const addProduct = () => {
+          fetch('/products', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, price: parseFloat(price) })
+          })
+            .then(res => res.json())
+            .then(product => setProducts([...products, product]));
+        };
+
+        return (
+          <div>
+            <h1>Products</h1>
+            <ul>
+              {products.map(p => (
+                <li key={p.id}>{p.name} - ${p.price}</li>
+              ))}
+            </ul>
+            <h2>Add Product</h2>
+            <input placeholder="Name" value={name} onChange={e => setName(e.target.value)} />
+            <input placeholder="Price" value={price} onChange={e => setPrice(e.target.value)} />
+            <button onClick={addProduct}>Add</button>
+          </div>
+        );
+      };
+
+      ReactDOM.render(<App />, document.getElementById('root'));
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a basic Flask API to serve and create products
- add simple React UI for viewing and adding products
- document backend and frontend usage

## Testing
- `python3 -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_686ca647b3a4832c973ce3175cc51e4b